### PR TITLE
Modify site to use php-mail without sendgrid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "wpackagist-plugin/import-eventbrite-events": "1.5.8",
         "wpackagist-plugin/lumturio-wp-monitor": "^1.0",
         "wpackagist-plugin/modal-window": "5.0.5",
-        "wpackagist-plugin/sendgrid-email-delivery-simplified": "1.11.8",
         "wpackagist-plugin/sharing-plus": "1.0.1",
         "wpackagist-plugin/site-health-tool-manager": "^1.1",
         "wpackagist-plugin/slicknav-mobile-menu": "^1.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b76640024b8fc5092a59d1a33b5cd2c",
+    "content-hash": "cba8b8def0527e10eaf5c6afc32f11fb",
     "packages": [
         {
             "name": "composer/installers",
@@ -460,24 +460,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/modal-window/"
-        },
-        {
-            "name": "wpackagist-plugin/sendgrid-email-delivery-simplified",
-            "version": "1.11.8",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/sendgrid-email-delivery-simplified/",
-                "reference": "tags/1.11.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/sendgrid-email-delivery-simplified.1.11.8.zip"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/sendgrid-email-delivery-simplified/"
         },
         {
             "name": "wpackagist-plugin/sharing-plus",

--- a/public/wp-content/plugins/myplugin/cf7-custom.php
+++ b/public/wp-content/plugins/myplugin/cf7-custom.php
@@ -82,9 +82,7 @@ function spouse_create_user_on_signup_form_submission(&$contact_form) {
   $headers = [];
   $headers[] = "From: Spouse-program <noreply@spouseprogram.fi> \r\n";
 
-  if(!wp_mail($email, $subject, $message, $headers)) {
-    // Mails won't go through on dev environment
-  }
+  wp_mail($email, $subject, $message, $headers);
 }
 
 function spouse_create_event_on_form_submission(&$contact_form){

--- a/public/wp-content/plugins/myplugin/cf7-custom.php
+++ b/public/wp-content/plugins/myplugin/cf7-custom.php
@@ -71,25 +71,20 @@ function spouse_create_user_on_signup_form_submission(&$contact_form) {
   $reset_link = wp_login_url() . "\r\n";
 
   $blogName = get_bloginfo('name');
-  $message = "Hi $username,<br>";
-  $message .= "An account has been created on $blogName for email address $email <br>";
-  $message .= "Username for your account: $username <br>";
-  $message .= "Automatically created password for your account: $password <br>";
-  $message .= "You can change your password on the profile <br>";
-  $message .= "You can login here: $reset_link <br>";
+  $message = "Hi $username, \r\n";
+  $message .= "An account has been created on $blogName for email address $email \r\n";
+  $message .= "Username for your account: $username \r\n";
+  $message .= "Automatically created password for your account: $password \r\n";
+  $message .= "You can change your password on the profile \r\n";
+  $message .= "You can login here: $reset_link \r\n";
 
   $subject = __("Your account on ".get_bloginfo( 'name'));
   $headers = [];
-  add_filter('wp_mail_content_type', 'set_html_content_type');
   $headers[] = "From: Spouse-program <noreply@spouseprogram.fi> \r\n";
 
-  if(!wp_mail($email, $subject, $message)) {
+  if(!wp_mail($email, $subject, $message, $headers)) {
     // Mails won't go through on dev environment
   }
-
-  // Reset content-type to avoid conflicts -- http://core.trac.wordpress.org/ticket/23578
-  remove_filter( 'wp_mail_content_type', 'set_html_content_type' );
-
 }
 
 function spouse_create_event_on_form_submission(&$contact_form){


### PR DESCRIPTION
Sendgrid causes issues with spam blockers. Removing the module and start to use backend mail system with php mail function. (Then this can be configured in the hosting environment.)

Removed the sendgrid-module from installation.
Added headers for mail sending.
Some code cleanups. 

Testing guide:
Register new user.
You should see nicely formatted mails in mailhog with sender like no-reply@spouseprogram.fi 



